### PR TITLE
Evi data dump

### DIFF
--- a/ee-remote-prediction-of-tree-mortality/export-masked-modis-imagery.js
+++ b/ee-remote-prediction-of-tree-mortality/export-masked-modis-imagery.js
@@ -10,7 +10,7 @@ var sn = ee.FeatureCollection("ft:1VX1Uny1uAIYdgfuvsjLJVw1wMkhmSZq7fCQ0gowV"),
 // Args: img, an image
 // Returns: an image with some "masking" which is really just filling all bands in with 1
 
-var quality_forest_mask = function(img) {
+var quality_mask = function(img) {
   var date = ee.Date(img.get('system:time_start')).format("YYYYMMdd");
   date = ee.Number.parse(date);
   

--- a/py-scripts/data-carpentry/.ipynb_checkpoints/export-masked-modis-time-series-from-ee-checkpoint.ipynb
+++ b/py-scripts/data-carpentry/.ipynb_checkpoints/export-masked-modis-time-series-from-ee-checkpoint.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -39,13 +39,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=92adc1b8473fe0c3e152a74a744f54f8&token=4d2a8bc5706b556c591c3d9be494313f\"/>"
+       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=92adc1b8473fe0c3e152a74a744f54f8&token=869b2b8cae63b1f9ec562a8dccffd960\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -72,86 +72,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Define the masking function that will determine which pixels are both forested AND of high MODIS quality.\n",
     "\n",
     "def quality_mask(img):\n",
-    "#   date = ee.Date(img.get('system:time_start')).format(\"YYYYMMdd\")\n",
-    "#   date = ee.Number.parse(date)\n",
-    "  \n",
     "  date = ee.Image(ee.Number(img.get('system:time_start'))).rename([\"date\"]).divide(1000)\n",
+    "  mask = ee.Image(1).rename([\"mask\"])\n",
     "     \n",
     "  quality_pixels = img.select([\"SummaryQA\"]).rename([\"quality_pixel\"]).eq(0)\n",
-    "  mask = ee.Image(1).rename([\"mask\"])\n",
-    "  clean_img = img.select([\"EVI\"]).addBands(date).addBands(mask).updateMask(quality_pixels).toInt32().clip(sn)\n",
-    "  export_img = clean_img\n",
-    "\n",
-    "#  clean_img = img.select([\n",
-    "        # \"NDVI\", \n",
-    "#        \"EVI\", \n",
-    "        # \"sur_refl_b01\", \n",
-    "        # \"sur_refl_b02\", \n",
-    "        # \"sur_refl_b03\", \n",
-    "        # \"sur_refl_b07\",\n",
-    "        # \"ViewZenith\",\n",
-    "        # \"SolarZenith\",\n",
-    "        # \"RelativeAzimuth\",\n",
-    "        # \"DayOfYear\",\n",
-    "        # \"SummaryQA\",\n",
-    "        # \"DetailedQA\"\n",
-    "#                          ]).addBands(date).updateMask(quality_pixels).toInt32().clip(sn)\n",
-    "#   In order to export a \"masked\" image, fill the masked pixels with a silly number\n",
-    "#   All \"masked\" pixels will have a value of 1 (or -9999 for the commented out code)\n",
-    "#   I switched it to 1 in an effort to save space?\n",
-    "\n",
-    "#   First, generate a dummy image with the same number of bands as the MODIS image\n",
-    "#   var filled_img = ee.Image([ -9999, -9999, -9999, \n",
-    "#                             -9999, -9999, -9999, \n",
-    "#                             -9999, -9999, -9999, \n",
-    "#                             -9999, -9999, -9999])\n",
-    "#  filled_img = ee.Image([\n",
-    "                        # -1, # NDVI\n",
-    "#                        -1, # EVI\n",
-    "                        # 0, # sur_refl_b01\n",
-    "                        # 0, # sur_refl_b02\n",
-    "                        # 0, # sur_refl_b03\n",
-    "                        # 0, # sur_refl_b07\n",
-    "                        # 0, # ViewZenith\n",
-    "                        # 0, # SolarZenith\n",
-    "                        # 0, # RelativeAzimuth\n",
-    "                        # 0, # DayOfYear\n",
-    "  #                      -1, # SummaryQA\n",
-    "                        # 0, # DetailedQA\n",
-    " #                       -1  # date\n",
-    "  #                      ]).rename([\n",
-    "                                   # \"NDVI\", \n",
-    "  #                                 \"EVI\", \n",
-    "                                   # \"sur_refl_b01\", \n",
-    "                                   # \"sur_refl_b02\", \n",
-    "                                   # \"sur_refl_b03\", \n",
-    "                                   # \"sur_refl_b07\",\n",
-    "                                   # \"ViewZenith\",\n",
-    "                                   # \"SolarZenith\",\n",
-    "                                   # \"RelativeAzimuth\",\n",
-    "                                   # \"DayOfYear\",\n",
-    " #                                  \"SummaryQA\",\n",
-    "                                   # \"DetailedQA\",\n",
-    " #                                  \"date\"])\n",
-    "\n",
-    "#   Where there is a mask in the clean image, replace the value of the clean image with the \n",
-    "#   value from the dummy image (with -1 in NDVI and EVI bands, 1 in SummaryQA band, and 0 elsewhere\n",
-    "#  export_img = filled_img.where(clean_img.mask(), clean_img).clip(sn.geometry().bounds())\n",
-    "#  export_img = ee.Image(export_img.copyProperties(clean_img, ['system:time_start']))\n",
+    "  \n",
+    "  export_img = img.select([\"EVI\"]).addBands(date).addBands(mask).updateMask(quality_pixels).toInt32().clip(sn)\n",
     "\n",
     "  return export_img;"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
@@ -173,20 +113,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'properties': {'system:index': '2000_02_18', 'system:asset_size': 28219636986, 'system:time_start': 950832000000, 'system:time_end': 952214400000}, 'version': 1493667561435000, 'type': 'Image', 'id': 'MODIS/006/MOD13Q1/2000_02_18', 'bands': [{'crs_transform': [231.65635826395825, 0.0, -20015109.353988, 0.0, -231.65635826395834, 10007554.676994], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'SR-ORG:6974', 'id': 'EVI', 'dimensions': [172800, 86400]}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'date'}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'mask'}]}\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
-       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=ba30babb76b9f02a1b90209fbcabd7b4&token=f449c0e8b347721903db9165ecf72ef4\"/>"
+       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=ba30babb76b9f02a1b90209fbcabd7b4&token=d0caf0ea6a70c321eaf90dfb95a55642\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -200,8 +133,8 @@
     "# Test the first image\n",
     "from IPython.display import Image, display, HTML\n",
     "\n",
-    "test_img = ee.Image(m_modis.toList(1, 0).get(0));\n",
-    "date = ee.Date(img.get('system:time_start')).format(\"YYYYMMdd\");\n",
+    "test_img = ee.Image(m_modis.toList(1, 0).get(0))\n",
+    "date = ee.Date(img.get('system:time_start')).format(\"YYYYMMdd\")\n",
     "\n",
     "thumburl = test_img.getThumbUrl({\n",
     "                'min':0, \n",
@@ -215,20 +148,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# loop through all images and create a feature representing the image number and acquisition date\n",
     "# Export each image upon looping\n",
@@ -237,18 +161,8 @@
     "# print(m_modis.size().getInfo());\n",
     "\n",
     "first_img = 0\n",
-    "num_imgs = 1\n",
+    "num_imgs = 397\n",
     "\n",
-    "# Create a list with num_imgs empty list elements\n",
-    "# metadata = ee.List.sequence({\n",
-    "#   'start': 0,\n",
-    "#   'end': 396,\n",
-    "#   'step': 1\n",
-    "# })\n",
-    "# metadata = [None]*num_imgs\n",
-    "print(first_img)\n",
-    "print(num_imgs)\n",
-    "# print(\"sn-whole-ts-modis-forest-quality-mask-%s\"%str(date))\n",
     "# Loop through all images, add the date to the appropriate list element, and export image\n",
     "for i in range(first_img, num_imgs):\n",
     "    img = ee.Image(m_modis.toList(1, i).get(0));\n",

--- a/py-scripts/data-carpentry/.ipynb_checkpoints/export-masked-modis-time-series-from-ee-checkpoint.ipynb
+++ b/py-scripts/data-carpentry/.ipynb_checkpoints/export-masked-modis-time-series-from-ee-checkpoint.ipynb
@@ -24,15 +24,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "391\n"
+      "397\n"
      ]
     }
    ],
    "source": [
     "# Import the required Images and ImageCollections\n",
-    "sn = ee.FeatureCollection(\"ft:1VX1Uny1uAIYdgfuvsjLJVw1wMkhmSZq7fCQ0gowV\");\n",
+    "sn = ee.FeatureCollection(\"ft:1vdDUTu09Rkw5qKR_DSfmFX-b_7kqy4E-pjxg9Sq6\");\n",
     "modis = ee.ImageCollection(\"MODIS/006/MOD13Q1\");\n",
-    "conifer_forest = ee.Image(\"users/mkoontz/sierra-nevada-250m-calveg-conifer-forested-pixels-by-whr-type-no-mask-full-cell\");\n",
     "\n",
     "# How many images are in the MODIS ImageCollection?\n",
     "print(modis.size().getInfo());"
@@ -40,13 +39,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=0467efc9383b6d968aa365ccde510e3d&token=cd0300cfbc0c79ce4499f579512bf195\"/>"
+       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=92adc1b8473fe0c3e152a74a744f54f8&token=4d2a8bc5706b556c591c3d9be494313f\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -61,9 +60,9 @@
     "\n",
     "from IPython.display import Image, display, HTML\n",
     "\n",
-    "thumburl = conifer_forest.getThumbUrl({\n",
+    "thumburl = ee.Image(modis.first()).select('EVI').getThumbUrl({\n",
     "                'min':0, \n",
-    "                'max':1          \n",
+    "                'max':8000          \n",
     "            })\n",
     "\n",
     "#print thumburl\n",
@@ -73,35 +72,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 56,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Define the masking function that will determine which pixels are both forested AND of high MODIS quality.\n",
     "\n",
-    "def quality_forest_mask(img):\n",
+    "def quality_mask(img):\n",
     "#   date = ee.Date(img.get('system:time_start')).format(\"YYYYMMdd\")\n",
     "#   date = ee.Number.parse(date)\n",
     "  \n",
     "  date = ee.Image(ee.Number(img.get('system:time_start'))).rename([\"date\"]).divide(1000)\n",
     "     \n",
     "  quality_pixels = img.select([\"SummaryQA\"]).rename([\"quality_pixel\"]).eq(0)\n",
+    "  mask = ee.Image(1).rename([\"mask\"])\n",
+    "  clean_img = img.select([\"EVI\"]).addBands(date).addBands(mask).updateMask(quality_pixels).toInt32().clip(sn)\n",
+    "  export_img = clean_img\n",
     "\n",
-    "  clean_img = img.select([\"NDVI\", \n",
-    "        \"EVI\", \n",
-    "        \"sur_refl_b01\", \n",
-    "        \"sur_refl_b02\", \n",
-    "        \"sur_refl_b03\", \n",
-    "        \"sur_refl_b07\",\n",
-    "        \"ViewZenith\",\n",
-    "        \"SolarZenith\",\n",
-    "        \"RelativeAzimuth\",\n",
-    "        \"DayOfYear\",\n",
-    "        \"SummaryQA\",\n",
-    "        \"DetailedQA\"]).addBands(date).updateMask(quality_pixels).updateMask(conifer_forest).toInt32()\n",
-    "\n",
+    "#  clean_img = img.select([\n",
+    "        # \"NDVI\", \n",
+    "#        \"EVI\", \n",
+    "        # \"sur_refl_b01\", \n",
+    "        # \"sur_refl_b02\", \n",
+    "        # \"sur_refl_b03\", \n",
+    "        # \"sur_refl_b07\",\n",
+    "        # \"ViewZenith\",\n",
+    "        # \"SolarZenith\",\n",
+    "        # \"RelativeAzimuth\",\n",
+    "        # \"DayOfYear\",\n",
+    "        # \"SummaryQA\",\n",
+    "        # \"DetailedQA\"\n",
+    "#                          ]).addBands(date).updateMask(quality_pixels).toInt32().clip(sn)\n",
     "#   In order to export a \"masked\" image, fill the masked pixels with a silly number\n",
     "#   All \"masked\" pixels will have a value of 1 (or -9999 for the commented out code)\n",
     "#   I switched it to 1 in an effort to save space?\n",
@@ -111,60 +112,81 @@
     "#                             -9999, -9999, -9999, \n",
     "#                             -9999, -9999, -9999, \n",
     "#                             -9999, -9999, -9999])\n",
-    "  filled_img = ee.Image([1, 1, 1, \n",
-    "                        1, 1, 1, \n",
-    "                        1, 1, 1, \n",
-    "                        1, 1, 1, 1]).rename([\"NDVI\", \n",
-    "                                                \"EVI\", \n",
-    "                                                \"sur_refl_b01\", \n",
-    "                                                \"sur_refl_b02\", \n",
-    "                                                \"sur_refl_b03\", \n",
-    "                                                \"sur_refl_b07\",\n",
-    "                                                \"ViewZenith\",\n",
-    "                                                \"SolarZenith\",\n",
-    "                                                \"RelativeAzimuth\",\n",
-    "                                                \"DayOfYear\",\n",
-    "                                                \"SummaryQA\",\n",
-    "                                                \"DetailedQA\",\n",
-    "                                                \"date\"])\n",
+    "#  filled_img = ee.Image([\n",
+    "                        # -1, # NDVI\n",
+    "#                        -1, # EVI\n",
+    "                        # 0, # sur_refl_b01\n",
+    "                        # 0, # sur_refl_b02\n",
+    "                        # 0, # sur_refl_b03\n",
+    "                        # 0, # sur_refl_b07\n",
+    "                        # 0, # ViewZenith\n",
+    "                        # 0, # SolarZenith\n",
+    "                        # 0, # RelativeAzimuth\n",
+    "                        # 0, # DayOfYear\n",
+    "  #                      -1, # SummaryQA\n",
+    "                        # 0, # DetailedQA\n",
+    " #                       -1  # date\n",
+    "  #                      ]).rename([\n",
+    "                                   # \"NDVI\", \n",
+    "  #                                 \"EVI\", \n",
+    "                                   # \"sur_refl_b01\", \n",
+    "                                   # \"sur_refl_b02\", \n",
+    "                                   # \"sur_refl_b03\", \n",
+    "                                   # \"sur_refl_b07\",\n",
+    "                                   # \"ViewZenith\",\n",
+    "                                   # \"SolarZenith\",\n",
+    "                                   # \"RelativeAzimuth\",\n",
+    "                                   # \"DayOfYear\",\n",
+    " #                                  \"SummaryQA\",\n",
+    "                                   # \"DetailedQA\",\n",
+    " #                                  \"date\"])\n",
     "\n",
     "#   Where there is a mask in the clean image, replace the value of the clean image with the \n",
-    "#   value from the dummy image (with all 1 (or -9999 from the commented out code))\n",
-    "  export_img = filled_img.where(clean_img.mask(), clean_img).clip(sn.geometry().bounds())\n",
-    "  export_img = ee.Image(export_img.copyProperties(clean_img, ['system:time_start']))\n",
+    "#   value from the dummy image (with -1 in NDVI and EVI bands, 1 in SummaryQA band, and 0 elsewhere\n",
+    "#  export_img = filled_img.where(clean_img.mask(), clean_img).clip(sn.geometry().bounds())\n",
+    "#  export_img = ee.Image(export_img.copyProperties(clean_img, ['system:time_start']))\n",
     "\n",
     "  return export_img;"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'properties': {'system:index': '2000_02_18', 'system:footprint': {'coordinates': [[[-121.61056999999998, 35.159639999999975], [-117.86847999999999, 35.159639999999975], [-117.86847999999999, 40.42550000000002], [-121.61056999999998, 40.42550000000002], [-121.61056999999998, 35.159639999999975]]], 'geodesic': False, 'type': 'Polygon'}, 'system:time_start': 950832000000}, 'bands': [{'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'NDVI', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'EVI', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'sur_refl_b01', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'sur_refl_b02', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'sur_refl_b03', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'sur_refl_b07', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'ViewZenith', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'SolarZenith', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'RelativeAzimuth', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'DayOfYear', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'SummaryQA', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'DetailedQA', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'date', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}], 'type': 'Image'}\n"
+      "{'properties': {'system:index': '2000_02_18', 'system:asset_size': 28219636986, 'system:time_start': 950832000000, 'system:time_end': 952214400000}, 'version': 1493667561435000, 'type': 'Image', 'id': 'MODIS/006/MOD13Q1/2000_02_18', 'bands': [{'crs_transform': [231.65635826395825, 0.0, -20015109.353988, 0.0, -231.65635826395834, 10007554.676994], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'SR-ORG:6974', 'id': 'EVI', 'dimensions': [172800, 86400]}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'date'}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'mask'}]}\n",
+      "['EVI', 'date', 'mask']\n"
      ]
     }
    ],
    "source": [
     "# Map the masking function to the MODIS image collection\n",
     "\n",
-    "m_modis = modis.map(quality_forest_mask);\n",
-    "print(ee.Image(m_modis.first()).getInfo());"
+    "m_modis = modis.map(quality_mask);\n",
+    "print(ee.Image(m_modis.first()).getInfo())\n",
+    "print(ee.Image(m_modis.first()).bandNames().getInfo())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'properties': {'system:index': '2000_02_18', 'system:asset_size': 28219636986, 'system:time_start': 950832000000, 'system:time_end': 952214400000}, 'version': 1493667561435000, 'type': 'Image', 'id': 'MODIS/006/MOD13Q1/2000_02_18', 'bands': [{'crs_transform': [231.65635826395825, 0.0, -20015109.353988, 0.0, -231.65635826395834, 10007554.676994], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'SR-ORG:6974', 'id': 'EVI', 'dimensions': [172800, 86400]}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'date'}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'mask'}]}\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
-       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=10dbeb1a72cb27ae32beb6e7463d5460&token=de552e949bd32f35996ade5d7d2161fb\"/>"
+       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=ba30babb76b9f02a1b90209fbcabd7b4&token=f449c0e8b347721903db9165ecf72ef4\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -177,11 +199,13 @@
    "source": [
     "# Test the first image\n",
     "from IPython.display import Image, display, HTML\n",
-    "test_img = ee.Image(m_modis.first()).select([\"EVI\"]).clip(sn);\n",
+    "\n",
+    "test_img = ee.Image(m_modis.toList(1, 0).get(0));\n",
+    "date = ee.Date(img.get('system:time_start')).format(\"YYYYMMdd\");\n",
     "\n",
     "thumburl = test_img.getThumbUrl({\n",
     "                'min':0, \n",
-    "                'max':100,\n",
+    "                'max':8000,\n",
     "            })\n",
     "\n",
     "#print thumburl\n",
@@ -191,14 +215,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 62,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "316\n"
+      "0\n",
+      "1\n"
      ]
     }
    ],
@@ -206,20 +233,21 @@
     "# loop through all images and create a feature representing the image number and acquisition date\n",
     "# Export each image upon looping\n",
     "\n",
-    "# There are 391 images\n",
+    "# There are 397 images as of 2017-06-04\n",
     "# print(m_modis.size().getInfo());\n",
     "\n",
-    "first_img = 316\n",
-    "num_imgs = 391\n",
+    "first_img = 0\n",
+    "num_imgs = 1\n",
     "\n",
     "# Create a list with num_imgs empty list elements\n",
     "# metadata = ee.List.sequence({\n",
     "#   'start': 0,\n",
-    "#   'end': 390,\n",
+    "#   'end': 396,\n",
     "#   'step': 1\n",
     "# })\n",
     "# metadata = [None]*num_imgs\n",
     "print(first_img)\n",
+    "print(num_imgs)\n",
     "# print(\"sn-whole-ts-modis-forest-quality-mask-%s\"%str(date))\n",
     "# Loop through all images, add the date to the appropriate list element, and export image\n",
     "for i in range(first_img, num_imgs):\n",
@@ -228,11 +256,12 @@
     "  \n",
     "    task = ee.batch.Export.image.toDrive(**{\n",
     "        'image': img, \n",
-    "        'description': \"sn-whole-ts-modis-forest-quality-mask-\" + str(date.getInfo()), \n",
-    "        'folder': 'ee/sierra-nevada-forest-quality-mask-modis-time-series', \n",
+    "        'description': \"sn_jep_modis_ts_quality_mask_epsg3310_\" + str(date.getInfo()), \n",
+    "        'folder': 'ee/sn_jep_modis_ts_quality_mask_epsg3310', \n",
     "        'scale': 250, \n",
     "        'region': sn.geometry().getInfo()['coordinates'], \n",
-    "        'crs': 'EPSG:3310'})\n",
+    "        'crs': 'EPSG:3310'\n",
+    "    })\n",
     "    task.start()"
    ]
   },

--- a/py-scripts/data-carpentry/.ipynb_checkpoints/export-masked-modis-time-series-from-ee-checkpoint.ipynb
+++ b/py-scripts/data-carpentry/.ipynb_checkpoints/export-masked-modis-time-series-from-ee-checkpoint.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -17,17 +17,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "397\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Import the required Images and ImageCollections\n",
     "sn = ee.FeatureCollection(\"ft:1vdDUTu09Rkw5qKR_DSfmFX-b_7kqy4E-pjxg9Sq6\");\n",
@@ -72,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,18 +83,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'properties': {'system:index': '2000_02_18', 'system:asset_size': 28219636986, 'system:time_start': 950832000000, 'system:time_end': 952214400000}, 'version': 1493667561435000, 'type': 'Image', 'id': 'MODIS/006/MOD13Q1/2000_02_18', 'bands': [{'crs_transform': [231.65635826395825, 0.0, -20015109.353988, 0.0, -231.65635826395834, 10007554.676994], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'SR-ORG:6974', 'id': 'EVI', 'dimensions': [172800, 86400]}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'date'}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'mask'}]}\n",
-      "['EVI', 'date', 'mask']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Map the masking function to the MODIS image collection\n",
     "\n",
@@ -170,7 +153,7 @@
     "  \n",
     "    task = ee.batch.Export.image.toDrive(**{\n",
     "        'image': img, \n",
-    "        'description': \"sn_jep_modis_ts_quality_mask_epsg3310_\" + str(date.getInfo()), \n",
+    "        'description': \"sn_jep_modis_ts_quality_mask_epsg3310_\" + i + \"_\" + str(date.getInfo()), \n",
     "        'folder': 'ee/sn_jep_modis_ts_quality_mask_epsg3310', \n",
     "        'scale': 250, \n",
     "        'region': sn.geometry().getInfo()['coordinates'], \n",

--- a/py-scripts/data-carpentry/export-masked-modis-time-series-from-ee.ipynb
+++ b/py-scripts/data-carpentry/export-masked-modis-time-series-from-ee.ipynb
@@ -17,22 +17,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "391\n"
+      "397\n"
      ]
     }
    ],
    "source": [
     "# Import the required Images and ImageCollections\n",
-    "sn = ee.FeatureCollection(\"ft:1VX1Uny1uAIYdgfuvsjLJVw1wMkhmSZq7fCQ0gowV\");\n",
+    "sn = ee.FeatureCollection(\"ft:1vdDUTu09Rkw5qKR_DSfmFX-b_7kqy4E-pjxg9Sq6\");\n",
     "modis = ee.ImageCollection(\"MODIS/006/MOD13Q1\");\n",
-    "conifer_forest = ee.Image(\"users/mkoontz/sierra-nevada-250m-calveg-conifer-forested-pixels-by-whr-type-no-mask-full-cell\");\n",
     "\n",
     "# How many images are in the MODIS ImageCollection?\n",
     "print(modis.size().getInfo());"
@@ -40,13 +39,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=0467efc9383b6d968aa365ccde510e3d&token=cd0300cfbc0c79ce4499f579512bf195\"/>"
+       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=92adc1b8473fe0c3e152a74a744f54f8&token=869b2b8cae63b1f9ec562a8dccffd960\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -61,9 +60,9 @@
     "\n",
     "from IPython.display import Image, display, HTML\n",
     "\n",
-    "thumburl = conifer_forest.getThumbUrl({\n",
+    "thumburl = ee.Image(modis.first()).select('EVI').getThumbUrl({\n",
     "                'min':0, \n",
-    "                'max':1          \n",
+    "                'max':8000          \n",
     "            })\n",
     "\n",
     "#print thumburl\n",
@@ -73,98 +72,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 72,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Define the masking function that will determine which pixels are both forested AND of high MODIS quality.\n",
     "\n",
-    "def quality_forest_mask(img):\n",
-    "#   date = ee.Date(img.get('system:time_start')).format(\"YYYYMMdd\")\n",
-    "#   date = ee.Number.parse(date)\n",
-    "  \n",
+    "def quality_mask(img):\n",
     "  date = ee.Image(ee.Number(img.get('system:time_start'))).rename([\"date\"]).divide(1000)\n",
+    "  mask = ee.Image(1).rename([\"mask\"])\n",
     "     \n",
     "  quality_pixels = img.select([\"SummaryQA\"]).rename([\"quality_pixel\"]).eq(0)\n",
-    "\n",
-    "  clean_img = img.select([\"NDVI\", \n",
-    "        \"EVI\", \n",
-    "        \"sur_refl_b01\", \n",
-    "        \"sur_refl_b02\", \n",
-    "        \"sur_refl_b03\", \n",
-    "        \"sur_refl_b07\",\n",
-    "        \"ViewZenith\",\n",
-    "        \"SolarZenith\",\n",
-    "        \"RelativeAzimuth\",\n",
-    "        \"DayOfYear\",\n",
-    "        \"SummaryQA\",\n",
-    "        \"DetailedQA\"]).addBands(date).updateMask(quality_pixels).updateMask(conifer_forest).toInt32()\n",
-    "\n",
-    "#   In order to export a \"masked\" image, fill the masked pixels with a silly number\n",
-    "#   All \"masked\" pixels will have a value of 1 (or -9999 for the commented out code)\n",
-    "#   I switched it to 1 in an effort to save space?\n",
-    "\n",
-    "#   First, generate a dummy image with the same number of bands as the MODIS image\n",
-    "#   var filled_img = ee.Image([ -9999, -9999, -9999, \n",
-    "#                             -9999, -9999, -9999, \n",
-    "#                             -9999, -9999, -9999, \n",
-    "#                             -9999, -9999, -9999])\n",
-    "  filled_img = ee.Image([1, 1, 1, \n",
-    "                        1, 1, 1, \n",
-    "                        1, 1, 1, \n",
-    "                        1, 1, 1, 1]).rename([\"NDVI\", \n",
-    "                                                \"EVI\", \n",
-    "                                                \"sur_refl_b01\", \n",
-    "                                                \"sur_refl_b02\", \n",
-    "                                                \"sur_refl_b03\", \n",
-    "                                                \"sur_refl_b07\",\n",
-    "                                                \"ViewZenith\",\n",
-    "                                                \"SolarZenith\",\n",
-    "                                                \"RelativeAzimuth\",\n",
-    "                                                \"DayOfYear\",\n",
-    "                                                \"SummaryQA\",\n",
-    "                                                \"DetailedQA\",\n",
-    "                                                \"date\"])\n",
-    "\n",
-    "#   Where there is a mask in the clean image, replace the value of the clean image with the \n",
-    "#   value from the dummy image (with all 1 (or -9999 from the commented out code))\n",
-    "  export_img = filled_img.where(clean_img.mask(), clean_img).clip(sn.geometry().bounds())\n",
-    "  export_img = ee.Image(export_img.copyProperties(clean_img, ['system:time_start']))\n",
+    "  \n",
+    "  export_img = img.select([\"EVI\"]).addBands(date).addBands(mask).updateMask(quality_pixels).toInt32().clip(sn)\n",
     "\n",
     "  return export_img;"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'properties': {'system:index': '2000_02_18', 'system:footprint': {'coordinates': [[[-121.61056999999998, 35.159639999999975], [-117.86847999999999, 35.159639999999975], [-117.86847999999999, 40.42550000000002], [-121.61056999999998, 40.42550000000002], [-121.61056999999998, 35.159639999999975]]], 'geodesic': False, 'type': 'Polygon'}, 'system:time_start': 950832000000}, 'bands': [{'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'NDVI', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'EVI', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'sur_refl_b01', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'sur_refl_b02', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'sur_refl_b03', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'sur_refl_b07', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'ViewZenith', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'SolarZenith', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'RelativeAzimuth', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'DayOfYear', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'SummaryQA', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'DetailedQA', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}, {'dimensions': [5, 6], 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'origin': [-122, 35], 'id': 'date', 'data_type': {'max': 2147483647, 'precision': 'int', 'min': -2147483648, 'type': 'PixelType'}, 'crs': 'EPSG:4326'}], 'type': 'Image'}\n"
+      "{'properties': {'system:index': '2000_02_18', 'system:asset_size': 28219636986, 'system:time_start': 950832000000, 'system:time_end': 952214400000}, 'version': 1493667561435000, 'type': 'Image', 'id': 'MODIS/006/MOD13Q1/2000_02_18', 'bands': [{'crs_transform': [231.65635826395825, 0.0, -20015109.353988, 0.0, -231.65635826395834, 10007554.676994], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'SR-ORG:6974', 'id': 'EVI', 'dimensions': [172800, 86400]}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'date'}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'mask'}]}\n",
+      "['EVI', 'date', 'mask']\n"
      ]
     }
    ],
    "source": [
     "# Map the masking function to the MODIS image collection\n",
     "\n",
-    "m_modis = modis.map(quality_forest_mask);\n",
-    "print(ee.Image(m_modis.first()).getInfo());"
+    "m_modis = modis.map(quality_mask);\n",
+    "print(ee.Image(m_modis.first()).getInfo())\n",
+    "print(ee.Image(m_modis.first()).bandNames().getInfo())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=10dbeb1a72cb27ae32beb6e7463d5460&token=de552e949bd32f35996ade5d7d2161fb\"/>"
+       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=ba30babb76b9f02a1b90209fbcabd7b4&token=d0caf0ea6a70c321eaf90dfb95a55642\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -177,11 +132,13 @@
    "source": [
     "# Test the first image\n",
     "from IPython.display import Image, display, HTML\n",
-    "test_img = ee.Image(m_modis.first()).select([\"EVI\"]).clip(sn);\n",
+    "\n",
+    "test_img = ee.Image(m_modis.toList(1, 0).get(0))\n",
+    "date = ee.Date(img.get('system:time_start')).format(\"YYYYMMdd\")\n",
     "\n",
     "thumburl = test_img.getThumbUrl({\n",
     "                'min':0, \n",
-    "                'max':100,\n",
+    "                'max':8000,\n",
     "            })\n",
     "\n",
     "#print thumburl\n",
@@ -191,36 +148,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "316\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "# loop through all images and create a feature representing the image number and acquisition date\n",
     "# Export each image upon looping\n",
     "\n",
-    "# There are 391 images\n",
+    "# There are 397 images as of 2017-06-04\n",
     "# print(m_modis.size().getInfo());\n",
     "\n",
-    "first_img = 316\n",
-    "num_imgs = 391\n",
+    "first_img = 0\n",
+    "num_imgs = 397\n",
     "\n",
-    "# Create a list with num_imgs empty list elements\n",
-    "# metadata = ee.List.sequence({\n",
-    "#   'start': 0,\n",
-    "#   'end': 390,\n",
-    "#   'step': 1\n",
-    "# })\n",
-    "# metadata = [None]*num_imgs\n",
-    "print(first_img)\n",
-    "# print(\"sn-whole-ts-modis-forest-quality-mask-%s\"%str(date))\n",
     "# Loop through all images, add the date to the appropriate list element, and export image\n",
     "for i in range(first_img, num_imgs):\n",
     "    img = ee.Image(m_modis.toList(1, i).get(0));\n",
@@ -228,11 +170,12 @@
     "  \n",
     "    task = ee.batch.Export.image.toDrive(**{\n",
     "        'image': img, \n",
-    "        'description': \"sn-whole-ts-modis-forest-quality-mask-\" + str(date.getInfo()), \n",
-    "        'folder': 'ee/sierra-nevada-forest-quality-mask-modis-time-series', \n",
+    "        'description': \"sn_jep_modis_ts_quality_mask_epsg3310_\" + str(date.getInfo()), \n",
+    "        'folder': 'ee/sn_jep_modis_ts_quality_mask_epsg3310', \n",
     "        'scale': 250, \n",
     "        'region': sn.geometry().getInfo()['coordinates'], \n",
-    "        'crs': 'EPSG:3310'})\n",
+    "        'crs': 'EPSG:3310'\n",
+    "    })\n",
     "    task.start()"
    ]
   },

--- a/py-scripts/data-carpentry/export-masked-modis-time-series-from-ee.ipynb
+++ b/py-scripts/data-carpentry/export-masked-modis-time-series-from-ee.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -39,13 +39,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=92adc1b8473fe0c3e152a74a744f54f8&token=869b2b8cae63b1f9ec562a8dccffd960\"/>"
+       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=92adc1b8473fe0c3e152a74a744f54f8&token=d12eebe1c127813c87514fc407028793\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -72,8 +72,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# Define the masking function that will determine which pixels are both forested AND of high MODIS quality.\n",
@@ -91,14 +93,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'properties': {'system:index': '2000_02_18', 'system:asset_size': 28219636986, 'system:time_start': 950832000000, 'system:time_end': 952214400000}, 'version': 1493667561435000, 'type': 'Image', 'id': 'MODIS/006/MOD13Q1/2000_02_18', 'bands': [{'crs_transform': [231.65635826395825, 0.0, -20015109.353988, 0.0, -231.65635826395834, 10007554.676994], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'SR-ORG:6974', 'id': 'EVI', 'dimensions': [172800, 86400]}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'date'}, {'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'data_type': {'precision': 'int', 'max': 2147483647, 'type': 'PixelType', 'min': -2147483648}, 'crs': 'EPSG:4326', 'id': 'mask'}]}\n",
+      "{'version': 1493667561435000, 'type': 'Image', 'bands': [{'data_type': {'type': 'PixelType', 'precision': 'int', 'max': 2147483647, 'min': -2147483648}, 'crs_transform': [231.65635826395825, 0.0, -20015109.353988, 0.0, -231.65635826395834, 10007554.676994], 'dimensions': [172800, 86400], 'crs': 'SR-ORG:6974', 'id': 'EVI'}, {'data_type': {'type': 'PixelType', 'precision': 'int', 'max': 2147483647, 'min': -2147483648}, 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'crs': 'EPSG:4326', 'id': 'date'}, {'data_type': {'type': 'PixelType', 'precision': 'int', 'max': 2147483647, 'min': -2147483648}, 'crs_transform': [1.0, 0.0, 0.0, 0.0, 1.0, 0.0], 'crs': 'EPSG:4326', 'id': 'mask'}], 'id': 'MODIS/006/MOD13Q1/2000_02_18', 'properties': {'system:index': '2000_02_18', 'system:time_end': 952214400000, 'system:asset_size': 28219636986, 'system:time_start': 950832000000}}\n",
       "['EVI', 'date', 'mask']\n"
      ]
     }
@@ -113,13 +115,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://earthengine.googleapis.com/api/thumb?thumbid=2239e525a5f3d3705661a85585c791f8&token=360d339dc1e73dec64025fa4be936fde\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
-       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=ba30babb76b9f02a1b90209fbcabd7b4&token=d0caf0ea6a70c321eaf90dfb95a55642\"/>"
+       "<img src=\"https://earthengine.googleapis.com/api/thumb?thumbid=2239e525a5f3d3705661a85585c791f8&token=360d339dc1e73dec64025fa4be936fde\"/>"
       ],
       "text/plain": [
        "<IPython.core.display.Image object>"
@@ -133,22 +142,21 @@
     "# Test the first image\n",
     "from IPython.display import Image, display, HTML\n",
     "\n",
-    "test_img = ee.Image(m_modis.toList(1, 0).get(0))\n",
-    "date = ee.Date(img.get('system:time_start')).format(\"YYYYMMdd\")\n",
+    "test_img = ee.Image(m_modis.toList(1, 0).get(0)).select([\"EVI\"])\n",
+    "# date = ee.Date(test_img.get('system:time_start')).format(\"YYYYMMdd\")\n",
     "\n",
     "thumburl = test_img.getThumbUrl({\n",
     "                'min':0, \n",
     "                'max':8000,\n",
     "            })\n",
     "\n",
-    "#print thumburl\n",
     "img_thumb = Image(url=thumburl)\n",
     "display(img_thumb)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "scrolled": true
    },
@@ -170,7 +178,7 @@
     "  \n",
     "    task = ee.batch.Export.image.toDrive(**{\n",
     "        'image': img, \n",
-    "        'description': \"sn_jep_modis_ts_quality_mask_epsg3310_\" + str(date.getInfo()), \n",
+    "        'description': \"sn_jep_modis_ts_quality_mask_epsg3310_\" + str(i) + \"_\" + str(date.getInfo()), \n",
     "        'folder': 'ee/sn_jep_modis_ts_quality_mask_epsg3310', \n",
     "        'scale': 250, \n",
     "        'region': sn.geometry().getInfo()['coordinates'], \n",


### PR DESCRIPTION
Complete the export of MODIS data using quality mask but no vegetation mask, and use Jepson delineation of the Sierra Nevada region.

Three bands per .GeoTIFF: "evi", "date", and "mask" though they are not labelled as such (blame Earth Engine).

"evi" is the Enhanced Vegetation Index value
"date" is the timestamp of the image in number of seconds elapsed since epoch (1/1/1970)
"mask" is how the other two bands should be masked (1 for include, 0 for exclude)